### PR TITLE
upgrade to new nginx mainline

### DIFF
--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Upload amd64 for later
         uses: actions/upload-artifact@v4
         with:
-          name: debian-to-upload-1.27.5-6
-          path: build-scripts/package-self-signatures/legacy-nginx_1.27.5~6_amd64.deb
+          name: debian-to-upload-1.29.0-1
+          path: build-scripts/package-self-signatures/legacy-nginx_1.29.0~1_amd64.deb
           if-no-files-found: error
           retention-days: 1
           compression-level: 0
@@ -40,7 +40,7 @@ jobs:
       - name: Download x86 Build Artifact
         uses: actions/download-artifact@v4
         with:
-          name: debian-to-upload-1.27.5-6
+          name: debian-to-upload-1.29.0-1
           path: build-scripts/package-self-signatures/
       - name: Download Backblaze CLI for ARM64
         run: |
@@ -67,8 +67,8 @@ jobs:
       - name: Add Packages to APT Repo
         run: |
           sudo apt install -y reprepro
-          reprepro -b ./apt/ --architecture amd64 includedeb production ./build-scripts/package-self-signatures/legacy-nginx_1.27.5~6_amd64.deb
-          reprepro -b ./apt/ --architecture arm64 includedeb production ./build-scripts/package-self-signatures/legacy-nginx_1.27.5~6_arm64.deb
+          reprepro -b ./apt/ --architecture amd64 includedeb production ./build-scripts/package-self-signatures/legacy-nginx_1.29.0~1_amd64.deb
+          reprepro -b ./apt/ --architecture arm64 includedeb production ./build-scripts/package-self-signatures/legacy-nginx_1.29.0~1_arm64.deb
       - name: Sync APT Repo
         run: b2 sync ./apt/ b2://${B2_BUCKET}/
         env:
@@ -96,4 +96,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: remverse/legacy-nginx:latest,remverse/legacy-nginx:1.27,remverse/legacy-nginx:1.27.5
+          tags: remverse/legacy-nginx:latest,remverse/legacy-nginx:1.29,remverse/legacy-nginx:1.29.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Legacy NGINX Builds #
 
-*current NGINX Version: 1.27.5*
+*current NGINX Version: 1.29.0*
 *current OpenSSL Version: 1.0.2u*
 
 While we're working on a longer term safer solution, rem-verse is making
@@ -34,7 +34,7 @@ sudo apt update
 sudo apt install legacy-nginx
 ```
 
-You can also use our prebuilt docker images: `docker pull remverse/legacy-nginx:1.27.5`
+You can also use our prebuilt docker images: `docker pull remverse/legacy-nginx:1.29.0`
 
 ### Building ###
 

--- a/build-scripts/building/nginx.sh
+++ b/build-scripts/building/nginx.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 if [[ "x$NGINX_VERSION" == "x" ]]; then
-  export NGINX_VERSION="1.27.5"
+  export NGINX_VERSION="1.29.0"
 fi
 if [[ "x$OPENSSL_VERSION" == "x" ]]; then
   export OPENSSL_VERSION="1.0.2u"

--- a/build-scripts/package-self-signatures/nfpm-amd64.yaml
+++ b/build-scripts/package-self-signatures/nfpm-amd64.yaml
@@ -6,7 +6,7 @@ homepage: "https://github.com/rem-verse/legacy-nginx"
 license: "MIT"
 maintainer: "Cynthia <cynthia@corp.rem-verse.email>"
 vendor: "RemVerse"
-version: "v1.27.5-6"
+version: "v1.29.0-1"
 
 arch: "amd64"
 platform: "linux"
@@ -22,64 +22,64 @@ conflicts:
   - nginx
 
 contents:
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/objs/nginx
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/objs/nginx
     dst: /usr/local/nginx/sbin/nginx
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/koi-win
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/koi-win
     dst: /usr/local/nginx/conf/koi-win
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/koi-utf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/koi-utf
     dst: /usr/local/nginx/conf/koi-utf
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/win-utf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/win-utf
     dst: /usr/local/nginx/conf/win-utf
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/mime.types
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/mime.types
     dst: /usr/local/nginx/conf/mime.types
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/mime.types
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/mime.types
     dst: /usr/local/nginx/conf/mime.types.default
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/fastcgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/fastcgi_params
     dst: /usr/local/nginx/conf/fastcgi_params
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/fastcgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/fastcgi_params
     dst: /usr/local/nginx/conf/fastcgi_params.default
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/fastcgi.conf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/fastcgi.conf
     dst: /usr/local/nginx/conf/fastcgi.conf
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/fastcgi.conf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/fastcgi.conf
     dst: /usr/local/nginx/conf/fastcgi.conf.default
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/uwsgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/uwsgi_params
     dst: /usr/local/nginx/conf/uwsgi_params
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/uwsgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/uwsgi_params
     dst: /usr/local/nginx/conf/uwsgi_params.default
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/scgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/scgi_params
     dst: /usr/local/nginx/conf/scgi_params
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/scgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/scgi_params
     dst: /usr/local/nginx/conf/scgi_params.default
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/nginx.conf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/nginx.conf
     dst: /usr/local/nginx/conf/nginx.conf
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/nginx.conf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/nginx.conf
     dst: /usr/local/nginx/conf/nginx.conf.default
     type: config
   - dst: /usr/local/nginx/logs
     type: dir
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/html/50x.html
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/html/50x.html
     dst: /usr/local/nginx/50x.html
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/html/index.html
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/html/index.html
     dst: /usr/local/nginx/index.html
     type: config|noreplace
   - dst: /usr/local/nginx/modules
     type: dir
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/objs/ngx_stream_module.so
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/objs/ngx_stream_module.so
     dst: /usr/local/nginx/modules/ngx_stream_module.so
   - src: /usr/local/nginx/sbin/nginx
     dst: /usr/sbin/nginx

--- a/build-scripts/package-self-signatures/nfpm-arm64.yaml
+++ b/build-scripts/package-self-signatures/nfpm-arm64.yaml
@@ -6,7 +6,7 @@ homepage: "https://github.com/rem-verse/legacy-nginx"
 license: "MIT"
 maintainer: "Cynthia <cynthia@corp.rem-verse.email>"
 vendor: "RemVerse"
-version: "v1.27.5-6"
+version: "v1.29.0-1"
 
 arch: "arm64"
 platform: "linux"
@@ -22,64 +22,64 @@ conflicts:
   - nginx
 
 contents:
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/objs/nginx
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/objs/nginx
     dst: /usr/local/nginx/sbin/nginx
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/koi-win
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/koi-win
     dst: /usr/local/nginx/conf/koi-win
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/koi-utf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/koi-utf
     dst: /usr/local/nginx/conf/koi-utf
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/win-utf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/win-utf
     dst: /usr/local/nginx/conf/win-utf
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/mime.types
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/mime.types
     dst: /usr/local/nginx/conf/mime.types
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/mime.types
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/mime.types
     dst: /usr/local/nginx/conf/mime.types.default
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/fastcgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/fastcgi_params
     dst: /usr/local/nginx/conf/fastcgi_params
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/fastcgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/fastcgi_params
     dst: /usr/local/nginx/conf/fastcgi_params.default
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/fastcgi.conf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/fastcgi.conf
     dst: /usr/local/nginx/conf/fastcgi.conf
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/fastcgi.conf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/fastcgi.conf
     dst: /usr/local/nginx/conf/fastcgi.conf.default
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/uwsgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/uwsgi_params
     dst: /usr/local/nginx/conf/uwsgi_params
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/uwsgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/uwsgi_params
     dst: /usr/local/nginx/conf/uwsgi_params.default
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/scgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/scgi_params
     dst: /usr/local/nginx/conf/scgi_params
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/scgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/scgi_params
     dst: /usr/local/nginx/conf/scgi_params.default
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/nginx.conf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/nginx.conf
     dst: /usr/local/nginx/conf/nginx.conf
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/nginx.conf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/nginx.conf
     dst: /usr/local/nginx/conf/nginx.conf.default
     type: config
   - dst: /usr/local/nginx/logs
     type: dir
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/html/50x.html
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/html/50x.html
     dst: /usr/local/nginx/50x.html
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/html/index.html
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/html/index.html
     dst: /usr/local/nginx/index.html
     type: config|noreplace
   - dst: /usr/local/nginx/modules
     type: dir
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/objs/ngx_stream_module.so
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/objs/ngx_stream_module.so
     dst: /usr/local/nginx/modules/ngx_stream_module.so
   - src: /usr/local/nginx/sbin/nginx
     dst: /usr/sbin/nginx

--- a/build-scripts/package-self-signatures/package.sh
+++ b/build-scripts/package-self-signatures/package.sh
@@ -7,9 +7,9 @@ cd "$SCRIPT_DIR/../../"
 export LEGACY_NGINX_DIR=$(pwd)
 cd "$SCRIPT_DIR"
 
-if [ ! -f "${LEGACY_NGINX_DIR}/build/nginx/1.27.5/nginx-1.27.5/objs/nginx" ]; then
-  echo "[+] Building NGINX 1.27.5 for packaging..."
-  export NGINX_VERSION="1.27.5"
+if [ ! -f "${LEGACY_NGINX_DIR}/build/nginx/1.29.0/nginx-1.29.0/objs/nginx" ]; then
+  echo "[+] Building NGINX 1.29.0 for packaging..."
+  export NGINX_VERSION="1.29.0"
   export OPENSSL_VERSION="1.0.2u"
   "${LEGACY_NGINX_DIR}"/build-scripts/building/nginx.sh
 fi

--- a/build-scripts/packaging/nfpm-amd64.yaml
+++ b/build-scripts/packaging/nfpm-amd64.yaml
@@ -6,7 +6,7 @@ homepage: "https://github.com/rem-verse/legacy-nginx"
 license: "MIT"
 maintainer: "Cynthia <cynthia@corp.rem-verse.email>"
 vendor: "RemVerse"
-version: "v1.27.5-6"
+version: "v1.29.0-1"
 
 arch: "amd64"
 platform: "linux"
@@ -22,64 +22,64 @@ conflicts:
   - nginx
 
 contents:
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/objs/nginx
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/objs/nginx
     dst: /usr/local/nginx/sbin/nginx
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/koi-win
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/koi-win
     dst: /usr/local/nginx/conf/koi-win
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/koi-utf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/koi-utf
     dst: /usr/local/nginx/conf/koi-utf
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/win-utf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/win-utf
     dst: /usr/local/nginx/conf/win-utf
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/mime.types
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/mime.types
     dst: /usr/local/nginx/conf/mime.types
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/mime.types
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/mime.types
     dst: /usr/local/nginx/conf/mime.types.default
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/fastcgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/fastcgi_params
     dst: /usr/local/nginx/conf/fastcgi_params
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/fastcgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/fastcgi_params
     dst: /usr/local/nginx/conf/fastcgi_params.default
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/fastcgi.conf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/fastcgi.conf
     dst: /usr/local/nginx/conf/fastcgi.conf
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/fastcgi.conf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/fastcgi.conf
     dst: /usr/local/nginx/conf/fastcgi.conf.default
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/uwsgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/uwsgi_params
     dst: /usr/local/nginx/conf/uwsgi_params
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/uwsgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/uwsgi_params
     dst: /usr/local/nginx/conf/uwsgi_params.default
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/scgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/scgi_params
     dst: /usr/local/nginx/conf/scgi_params
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/scgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/scgi_params
     dst: /usr/local/nginx/conf/scgi_params.default
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/nginx.conf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/nginx.conf
     dst: /usr/local/nginx/conf/nginx.conf
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/nginx.conf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/nginx.conf
     dst: /usr/local/nginx/conf/nginx.conf.default
     type: config
   - dst: /usr/local/nginx/logs
     type: dir
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/html/50x.html
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/html/50x.html
     dst: /usr/local/nginx/50x.html
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/html/index.html
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/html/index.html
     dst: /usr/local/nginx/index.html
     type: config|noreplace
   - dst: /usr/local/nginx/modules
     type: dir
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/objs/ngx_stream_module.so
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/objs/ngx_stream_module.so
     dst: /usr/local/nginx/modules/ngx_stream_module.so
   - src: /usr/local/nginx/sbin/nginx
     dst: /usr/sbin/nginx

--- a/build-scripts/packaging/nfpm-arm64.yaml
+++ b/build-scripts/packaging/nfpm-arm64.yaml
@@ -6,7 +6,7 @@ homepage: "https://github.com/rem-verse/legacy-nginx"
 license: "MIT"
 maintainer: "Cynthia <cynthia@corp.rem-verse.email>"
 vendor: "RemVerse"
-version: "v1.27.5-6"
+version: "v1.29.0-1"
 
 arch: "arm64"
 platform: "linux"
@@ -22,64 +22,64 @@ conflicts:
   - nginx
 
 contents:
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/objs/nginx
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/objs/nginx
     dst: /usr/local/nginx/sbin/nginx
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/koi-win
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/koi-win
     dst: /usr/local/nginx/conf/koi-win
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/koi-utf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/koi-utf
     dst: /usr/local/nginx/conf/koi-utf
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/win-utf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/win-utf
     dst: /usr/local/nginx/conf/win-utf
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/mime.types
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/mime.types
     dst: /usr/local/nginx/conf/mime.types
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/mime.types
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/mime.types
     dst: /usr/local/nginx/conf/mime.types.default
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/fastcgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/fastcgi_params
     dst: /usr/local/nginx/conf/fastcgi_params
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/fastcgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/fastcgi_params
     dst: /usr/local/nginx/conf/fastcgi_params.default
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/fastcgi.conf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/fastcgi.conf
     dst: /usr/local/nginx/conf/fastcgi.conf
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/fastcgi.conf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/fastcgi.conf
     dst: /usr/local/nginx/conf/fastcgi.conf.default
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/uwsgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/uwsgi_params
     dst: /usr/local/nginx/conf/uwsgi_params
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/uwsgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/uwsgi_params
     dst: /usr/local/nginx/conf/uwsgi_params.default
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/scgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/scgi_params
     dst: /usr/local/nginx/conf/scgi_params
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/scgi_params
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/scgi_params
     dst: /usr/local/nginx/conf/scgi_params.default
     type: config
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/nginx.conf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/nginx.conf
     dst: /usr/local/nginx/conf/nginx.conf
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/conf/nginx.conf
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/conf/nginx.conf
     dst: /usr/local/nginx/conf/nginx.conf.default
     type: config
   - dst: /usr/local/nginx/logs
     type: dir
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/html/50x.html
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/html/50x.html
     dst: /usr/local/nginx/50x.html
     type: config|noreplace
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/html/index.html
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/html/index.html
     dst: /usr/local/nginx/index.html
     type: config|noreplace
   - dst: /usr/local/nginx/modules
     type: dir
-  - src: ../../build/nginx/1.27.5/nginx-1.27.5/objs/ngx_stream_module.so
+  - src: ../../build/nginx/1.29.0/nginx-1.29.0/objs/ngx_stream_module.so
     dst: /usr/local/nginx/modules/ngx_stream_module.so
   - src: /usr/local/nginx/sbin/nginx
     dst: /usr/sbin/nginx

--- a/build-scripts/packaging/package.sh
+++ b/build-scripts/packaging/package.sh
@@ -7,9 +7,9 @@ cd "$SCRIPT_DIR/../../"
 export LEGACY_NGINX_DIR=$(pwd)
 cd "$SCRIPT_DIR"
 
-if [ ! -f "${LEGACY_NGINX_DIR}/build/nginx/1.27.5/nginx-1.27.5/objs/nginx" ]; then
-  echo "[+] Building NGINX 1.27.5 for packaging..."
-  export NGINX_VERSION="1.27.5"
+if [ ! -f "${LEGACY_NGINX_DIR}/build/nginx/1.29.0/nginx-1.29.0/objs/nginx" ]; then
+  echo "[+] Building NGINX 1.29.0 for packaging..."
+  export NGINX_VERSION="1.29.0"
   export OPENSSL_VERSION="1.0.2u"
   "${LEGACY_NGINX_DIR}"/build-scripts/building/nginx.sh
 fi


### PR DESCRIPTION
1.29.0 dropped today, so upgrade legacy-nginx to 1.29.0 too. See https://nginx.org/en/CHANGES for more information.